### PR TITLE
Allow usage with http://localhost/<subfolder>/

### DIFF
--- a/src/RequestFilter.php
+++ b/src/RequestFilter.php
@@ -62,6 +62,7 @@ class RequestFilter implements \RequestFilter
         if (Director::isDev()) {
             $response->addHeader("X-Clockwork-Id", $this->clockwork->getRequest()->id);
             $response->addHeader("X-Clockwork-Version", Clockwork::VERSION);
+            $response->addHeader('X-Clockwork-Path', Director::baseURL() . '__clockwork/');
             $this->clockwork->resolveRequest();
             $this->clockwork->storeRequest();
         }


### PR DESCRIPTION
Needs to prefix the base URL, otherwise the extension tries
to access /__clockwork on the root.
